### PR TITLE
Log out at the end to avoid dangling/orphaned sessions.

### DIFF
--- a/craigslist-renew.py
+++ b/craigslist-renew.py
@@ -161,6 +161,14 @@ def login():
     except NoSuchElementException:
         return
 
+# logout to avoid dangling sessions
+def logout():
+    try:
+        driver.find_element_by_link_text('log out').click()
+    except NoSuchElementException:
+        return
+
+
 # initialize logging
 def init_logging():
     handlers = []
@@ -234,6 +242,9 @@ if __name__ == '__main__':
             check_expired()
         else:
             renew_posts()
+
+        # Log out to avoid dangling sessions.
+        logout()
 
     except KeyError as e:
         log.error('Parameter {} not defined in config file'.format(e))


### PR DESCRIPTION
Without this change, a new session is created every time the script runs and it is never closed. You can verify this under the "settings" tab in Craiglist's web UI. 

With this change, the created session is torn down at the end. 