### PR TITLE
Force selenium to always use preinstalled driver

### DIFF
--- a/craigslist-renew.py
+++ b/craigslist-renew.py
@@ -9,6 +9,7 @@
 import atexit
 import logging
 import re
+import shutil
 import sys
 from argparse import ArgumentParser, FileType
 from bs4 import BeautifulSoup
@@ -193,12 +194,19 @@ def init_webdriver():
     options.add_argument(f'user-agent={UserAgent().chrome}')
 
     if not config.get('webdriver'):
+        service = webdriver.ChromeService(
+            executable_path=shutil.which('chromedriver')
+        )
         driver = webdriver.Chrome(
+            service=service,
             options=options
         )
     elif not config['webdriver'].startswith('http'):
+        service = webdriver.ChromeService(
+            executable_path=config['webdriver']
+        )
         driver = webdriver.Chrome(
-            executable_path=config['webdriver'],
+            service=service,
             options=options
         )
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ beautifulsoup4==4.12.2
 fake-useragent==1.2.1
 html5lib==1.1
 PyYAML==6.0.1
-selenium==4.11.2
+selenium==4.12.0


### PR DESCRIPTION
As of Selenium 4.11, in the event no execution path is provided, its manager will now automatically download the latest [Chrome For Testing](https://googlechromelabs.github.io/chrome-for-testing/) version. Since these prebuild packages cannot run on an Alpine based Docker image, it prevented the local webdriver support docker image from running after bumping the Selenium package to 4.11.2 last month (#15).