### PR TITLE
Run as unprivileged user inside docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@ FROM python:3-alpine
 
 WORKDIR /app
 
-RUN apk add --no-cache chromium
+RUN apk add --no-cache chromium shadow su-exec && \
+    groupadd -g 1000 appuser && \
+    useradd -u 1000 -g appuser -s /bin/sh -m appuser
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt --no-cache-dir
 
-COPY craigslist-renew.py .
+COPY craigslist-renew.py docker-entrypoint.sh ./
 
 VOLUME /data
 
-ENTRYPOINT ["python", "craigslist-renew.py", "/data/config.yml"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,15 @@ You can only renew a post so many times before it expires, so to get notified ab
 | :---: | --- |
 | `latest` | Latest stable release |
 
-> **Note:** The `local` and `remote` tags are no longer supported. Please use `latest` instead.
+> The `local` and `remote` tags are no longer supported. Please use `latest` instead.
+
+### Environment Variables
+| Variable | Default | Description |
+| :---: | :---: | --- |
+| `PUID` | Auto-detected from `/data` | User ID to run the script as |
+| `PGID` | Auto-detected from `/data` | Group ID to run the script as |
+
+> By default, the container will automatically match the ownership of your data directory. If the ownership cannot be determined, it will fall back to `1000:1000`. You can override this behavior by setting `PUID` and `PGID` explicitly. Note that running as root (`PUID=0` or `PGID=0`) is not supported.
 
 ### Run commands
 

--- a/craigslist-renew.py
+++ b/craigslist-renew.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # This script logs in to your craigslist account and renews all posts that can be renewed
 # The script should be invoked with a config file in yaml format containing the following info:
 # ---

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+CURRENT_UID=$(id -u appuser)
+CURRENT_GID=$(id -g appuser)
+
+CURRENT_HOME=$(getent passwd appuser | cut -d ":" -f6)
+
+DATA_UID=$(stat -c %u /data 2>/dev/null)
+DATA_GID=$(stat -c %g /data 2>/dev/null)
+
+PUID=${PUID:-${DATA_UID:-1000}}
+PGID=${PGID:-${DATA_GID:-1000}}
+
+# Exit if root user
+if [ "${PUID}" = "0" ] || [ "${PGID}" = "0" ]; then
+    echo "Error: Running as root is not supported. Please set PUID and PGID to non-root values."
+    exit 1
+fi
+
+# Update group if needed
+if [ "${CURRENT_GID}" != "${PGID}" ]; then
+    groupmod -o -g "${PGID}" appuser
+fi
+
+# Update user if needed
+if [ "${CURRENT_UID}" != "${PUID}" ]; then
+    usermod -o -u "${PUID}" appuser
+fi
+
+# Fix ownership of home directory if needed
+if [ -d "${CURRENT_HOME}" ] && \
+   [ "$(stat -c %u:%g "${CURRENT_HOME}" 2>/dev/null)" != "${PUID}:${PGID}" ]; then
+    chown -R appuser:appuser /home/appuser
+fi
+
+# Fix ownership of /data if needed (non-recursive)
+if [ -d /data ] && \
+   [ "$(stat -c %u:%g /data 2>/dev/null)" != "${PUID}:${PGID}" ]; then
+    chown appuser:appuser /data
+fi
+
+# Launch the app as appuser
+exec su-exec appuser \
+    python craigslist-renew.py /data/config.yml "$@"


### PR DESCRIPTION
## Changes

### Dockerfile
- Add `shadow` and `su-exec` packages for user management
- Create `appuser` with default UID/GID `1000`
- Switch entrypoint from direct Python invocation to `docker-entrypoint.sh`

### docker-entrypoint.sh
- Add new entrypoint script to manage user/group setup at runtime
- Auto-detect PUID/PGID from `/data` directory ownership
- Fall back to `1000:1000` if ownership cannot be determined
- Allow override via `PUID` and `PGID` environment variables
- Exit with error if running as root
- Fix ownership of home directory and `/data` when UID/GID changes
- Launch script as `appuser` using `su-exec`

### README
- Add environment variables section documenting `PUID` and `PGID`
- Remove `**Note:**` prefix from blockquotes for consistency

### Other
- Replace `#!/usr/bin/env python3` with `#!/usr/bin/env python` for broader compatibility